### PR TITLE
Use dedicated BATC FFT endpoint, and remove BATC analytics tracking.

### DIFF
--- a/board/pluto/overlay/www/lib/wf.js
+++ b/board/pluto/overlay/www/lib/wf.js
@@ -948,13 +948,3 @@ window.addEventListener("orientationchange", checkOrientation, false);
 
 // Android doesn't always fire orientationChange on 180 degree turns
 setInterval(checkOrientation, 2000);
-
-const ping_interval = 10*1000;
-function ping() {
-  var request = new XMLHttpRequest();
-  request.open('GET', 'https://eshail.batc.org.uk/a.gif', true);
-  request.send();
-  request = null;
-  setTimeout(ping, ping_interval);
-}
-setTimeout(ping, ping_interval);

--- a/board/pluto/overlay/www/lib/wf.js
+++ b/board/pluto/overlay/www/lib/wf.js
@@ -1,5 +1,5 @@
-var ws_url = "wss://eshail.batc.org.uk/wb/fft_m0dtslivetune";
-var ws_name = 'fft';
+var ws_url = "wss://eshail.batc.org.uk/wb/fft";
+var ws_name = 'fft_f5oeoplutofw';
 
 if(typeof ws_url_override !== 'undefined')
 {


### PR DESCRIPTION
Hi Evariste,

In the future, please ask us before putting out software that relies on the availability and bandwidth of the BATC services in this way.

1. This uses your own FFT websocket endpoint on the server, which means I can easily identify which software (mine/Rob's/yours) is causing a problem when a problem occurs.
2. This removes the BATC analytics tracking. As much as I enjoy receiving the details of everyone's home usage of their PlutoSDRs, it's not what I want to be logging.
3. Please place some credit to the BATC/AMSAT-UK for the feed. Given the cost and effort put into keeping it running by these organisations we would like to have some recognition in helping you provide this functionality, also on the technical side several of your users currently believe that this is received locally by the PlutoSDR.

The current way that you're using the websocket URL only works due to a bug at my end, which I'll fix in a few days, so please push this change through before then.

Cheers,
Phil M0DNY